### PR TITLE
renamed specFolderName to specNameMatcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Then add this line to your project's `grunt.js` grunt file:
 ```javascript
 grunt.initConfig({
   jasmine_node: {
-    specFolderName: "./spec",
+    specNameMatcher: "./spec", // load only specs containing specNameMatcher
     projectRoot: ".",
     requirejs: false,
     forceExit: true,

--- a/tasks/jasmine-node-task.js
+++ b/tasks/jasmine-node-task.js
@@ -13,7 +13,7 @@ module.exports = function (grunt) {
 
       var projectRoot     = grunt.config("jasmine_node.projectRoot") || ".";
       var source          = grunt.config("jasmine_node.source") || "src";
-      var specFolderName  = grunt.config("jasmine_node.specFolderName") || "spec";
+      var specNameMatcher = grunt.config("jasmine_node.specNameMatcher") || "spec";
       var isVerbose       = grunt.config("jasmine_node.verbose") || true;
       var showColors      = grunt.config("jasmine_node.colors") || true;
       var teamcity        = grunt.config("jasmine_node.teamcity") || false;
@@ -37,7 +37,7 @@ module.exports = function (grunt) {
       // Tell grunt this task is asynchronous.
       var done = this.async();
 
-      var regExpSpec = new RegExp(match + (matchall ? "" : specFolderName + "\\.") + "(" + extensions + ")$", 'i');
+      var regExpSpec = new RegExp(match + (matchall ? "" : specNameMatcher + "\\.") + "(" + extensions + ")$", 'i');
       var onComplete = function(runner, log) {
         var exitCode;
         util.print('\n');


### PR DESCRIPTION
specFolderName was confusing (at least to me) because it really is a name matcher. 

https://github.com/mhevery/jasmine-node/blob/master/lib/jasmine-node/cli.js#L160

https://github.com/mhevery/jasmine-node/blob/master/lib/jasmine-node/index.js#L70
