### PR TITLE
isVerbose and showColors fix

### DIFF
--- a/tasks/jasmine-node-task.js
+++ b/tasks/jasmine-node-task.js
@@ -1,5 +1,6 @@
 module.exports = function (grunt) {
-
+    'use strict';
+    
     grunt.registerTask("jasmine_node", "Runs jasmine-node.", function() {
       var jasmine = require('jasmine-node');
       var util;
@@ -30,6 +31,7 @@ module.exports = function (grunt) {
       if (_.isUndefined(isVerbose)) {
         isVerbose = true;
       }
+      
       if (_.isUndefined(showColors)) {
         showColors = true;
       }


### PR DESCRIPTION
- Values with which default to `true` wouldn't be set correctly as `||` always evaluated to the default value.
- Add `'use strict'` so jshint is happy.
