### PR TITLE
Make compatible with grunt@0.4.0a

### DIFF
--- a/tasks/jasmine-node-task.js
+++ b/tasks/jasmine-node-task.js
@@ -4,8 +4,10 @@ module.exports = function (grunt) {
     grunt.registerTask("jasmine_node", "Runs jasmine-node.", function() {
       var jasmine = require('jasmine-node');
       var util;
+      // TODO: ditch this when grunt v0.4 is released
+      grunt.util = grunt.util || grunt.utils;
       var Path = require('path');
-      var _ = grunt.utils._;
+      var _ = grunt.util._;
 
       try {
           util = require('util');


### PR DESCRIPTION
I've made a fix so that it's compatible with new stable and the devel version of grunt. It would be great to add this to the package as testacular depends on my fork right now and it would be great to depend on the npm version again.
