### PR TITLE
Handle changed public API of jasmine-node

### DIFF
--- a/tasks/jasmine-node-task.js
+++ b/tasks/jasmine-node-task.js
@@ -67,18 +67,33 @@ module.exports = function (grunt) {
         done();
       };
 
+      var options = {
+        specFolder:   projectRoot,
+        onComplete:   onComplete,
+        isVerbose:    isVerbose,
+        showColors:   showColors,
+        teamcity:     teamcity,
+        useRequireJs: useRequireJs,
+        regExpSpec:   regExpSpec,
+        junitreport:  junitreport
+      };
+
+      // order is preserved in node.js
+      var legacyArguments = Object.keys(options).map(function(key) {
+        return options[key];
+      });
+
       try {
-        jasmine.executeSpecsInFolder(projectRoot,
-          onComplete,
-          isVerbose,
-          showColors,
-          teamcity,
-          useRequireJs,
-          regExpSpec,
-          jUnit);
+        // for jasmine-node@1.0.27 individual arguments need to be passed
+        jasmine.executeSpecsInFolder.apply(this, legacyArguments);
       }
       catch (e) {
-        console.log(e);
+        try {
+          // since jasmine-node@1.0.28 an options object need to be passed
+          jasmine.executeSpecsInFolder(options);
+        } catch (e) {
+          console.log('Failed to execute "jasmine.executeSpecsInFolder": ' + e.stack);
+        }
       }
     });
 };


### PR DESCRIPTION
Two days ago version 1.0.28 of  `jasmine-node` was released (https://github.com/mhevery/jasmine-node/commit/ac0912b0f00d28b54a0efaa4ab026c27919c8c29) and they changed the signature `executeSpecsInFolder`: https://github.com/mhevery/jasmine-node/commit/02f11fc369fd8007e2e3d14fbe53453cc3b814d4.

This pull request fixes the execution of `grunt-jasmine-node` with version 1.0.28 of `jasmine-node` while still supporting the old signature of `executeSpecsInFolder`.
