### PR TITLE
[fix] Update to node-jasmine@1.0.28 and implement new options passing.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,11 +29,11 @@
   "scripts" : {
   },
   "dependencies" : {
-    "jasmine-node": "*"
+    "jasmine-node": ">= 1.0.28"
   },
   "devDependencies" : {
     "grunt" : "~0.3.9",
-    "jasmine-node": "*"
+    "jasmine-node": ">= 1.0.28"
   },
   "keywords" : [
     "gruntplugin",

--- a/tasks/jasmine-node-task.js
+++ b/tasks/jasmine-node-task.js
@@ -66,16 +66,20 @@ module.exports = function (grunt) {
 
         done();
       };
+      var options = {
+        specFolder: projectRoot,
+        onComplete: onComplete,
+        isVerbose: isVerbose,
+        showColors: showColors,
+        teamcity: teamcity,
+        useRequireJS: useRequireJs,
+        regExpSpec: regExpSpec,
+        junitreport: jUnit
+      };
+
 
       try {
-        jasmine.executeSpecsInFolder(projectRoot,
-          onComplete,
-          isVerbose,
-          showColors,
-          teamcity,
-          useRequireJs,
-          regExpSpec,
-          jUnit);
+        jasmine.executeSpecsInFolder(options);
       }
       catch (e) {
         console.log(e);


### PR DESCRIPTION
With the new version of node-jasmine the task just fails because there was an api change of `jasmine.executeSpecsInFolder`. This fixes this.
