### PR TITLE
Using the passed jUnit config if set

### DIFF
--- a/tasks/jasmine-node-task.js
+++ b/tasks/jasmine-node-task.js
@@ -75,7 +75,7 @@ module.exports = function (grunt) {
         teamcity:     teamcity,
         useRequireJs: useRequireJs,
         regExpSpec:   regExpSpec,
-        junitreport:  junitreport
+        junitreport:  jUnit
       };
 
       // order is preserved in node.js


### PR DESCRIPTION
Just having a look at this to compare the XML JUnit output to another
JUnit/ PhantomJS task I'm using and noticed that as written it seems to
ignore the passed in JUnit configuration and it's impossible to turn
the JUnit reporting on... 

I think this change makes it behave as expected?
