### PR TITLE
Update task to work with jasmine-node 1.5.0

### DIFF
--- a/tasks/jasmine-node-task.js
+++ b/tasks/jasmine-node-task.js
@@ -68,7 +68,7 @@ module.exports = function (grunt) {
       };
 
       var options = {
-        specFolder:   projectRoot,
+        specFolders:  [projectRoot],
         onComplete:   onComplete,
         isVerbose:    isVerbose,
         showColors:   showColors,


### PR DESCRIPTION
In the latest jasmine-node version, the option `specFolder` is changed to `specFolders` and is now of type `Array`.
