### PR TITLE
ADD Helpers to jasmine

### DIFF
--- a/tasks/jasmine-node-task.js
+++ b/tasks/jasmine-node-task.js
@@ -83,6 +83,11 @@ module.exports = function (grunt) {
         return options[key];
       });
 
+      if(useHelpers){
+        jasmine.loadHelpersInFolder(projectRoot,
+        new RegExp("helpers?\\.(" + extensions + ")$", 'i'));
+      }
+
       try {
         // for jasmine-node@1.0.27 individual arguments need to be passed
         jasmine.executeSpecsInFolder.apply(this, legacyArguments);


### PR DESCRIPTION
Now if you have defined helpers in your project, it will be included in the jasmine framework
