### PR TITLE
jasmine_node expects "specFolders" not "specFolder"

### DIFF
--- a/tasks/jasmine-node-task.js
+++ b/tasks/jasmine-node-task.js
@@ -15,7 +15,7 @@ module.exports = function (grunt) {
           util = require('sys');
       }
 
-      var specFolders     = grunt.config("jasmine_node.specFolders") || ".";
+      var specFolders     = grunt.config("jasmine_node.specFolders") || [];
       var source          = grunt.config("jasmine_node.source") || "src";
       var specNameMatcher = grunt.config("jasmine_node.specNameMatcher") || "spec";
       var teamcity        = grunt.config("jasmine_node.teamcity") || false;
@@ -29,6 +29,10 @@ module.exports = function (grunt) {
 
       var isVerbose       = grunt.config("jasmine_node.verbose");
       var showColors      = grunt.config("jasmine_node.colors");
+
+      if(grunt.config("jasmine_node.projectRoot")){
+        specFolders.push(grunt.config("jasmine_node.projectRoot"));
+      }
 
       if (_.isUndefined(isVerbose)) {
         isVerbose = true;


### PR DESCRIPTION
I was working on https://github.com/Esri/Terraformer and upgrading from v0.0.5 to v0.0.6 and encountered the following error...

```
Running "jasmine_node" task
Failed to execute "jasmine.executeSpecsInFolder": TypeError: Cannot call method 'forEach' of undefined
    at Object.exports.load (/Users/patricklocal/Projects/contrib/grunt-jasmine-node/node_modules/jasmine-node/lib/jasmine-node/spec-collection.js:19:13)
    at Object.jasmine.executeSpecsInFolder (/Users/patricklocal/Projects/contrib/grunt-jasmine-node/node_modules/jasmine-node/lib/jasmine-node/index.js:91:9)
    at Object.module.exports (/Users/patricklocal/Projects/contrib/grunt-jasmine-node/tasks/jasmine-node-task.js:97:19)
    at Object.task.registerTask.thisTask.fn (/Users/patricklocal/Projects/contrib/grunt-jasmine-node/node_modules/grunt/lib/grunt/task.js:58:16)
    at Task.<anonymous> (/Users/patricklocal/Projects/contrib/grunt-jasmine-node/node_modules/grunt/lib/util/task.js:343:36)
    at Task.<anonymous> (/Users/patricklocal/Projects/contrib/grunt-jasmine-node/node_modules/grunt/lib/util/task.js:319:9)
    at Task.<anonymous> (/Users/patricklocal/Projects/contrib/grunt-jasmine-node/node_modules/grunt/lib/util/task.js:346:11)
    at Task.<anonymous> (/Users/patricklocal/Projects/contrib/grunt-jasmine-node/node_modules/grunt/lib/util/task.js:319:9)
    at Task.<anonymous> (/Users/patricklocal/Projects/contrib/grunt-jasmine-node/node_modules/grunt/lib/util/task.js:346:11)
    at Task.<anonymous> (/Users/patricklocal/Projects/contrib/grunt-jasmine-node/node_modules/grunt/lib/util/task.js:319:9)
```

I dug into this a little and and found that jasmine node expects a `specFolders` option not `specFolder` which is what the grunt task was using.

See https://github.com/mhevery/jasmine-node/blob/master/lib/jasmine-node/index.js#L72 and https://github.com/mhevery/jasmine-node/blob/master/lib/jasmine-node/index.js#L91 then https://github.com/mhevery/jasmine-node/blob/master/lib/jasmine-node/spec-collection.js#L19

When I run `grunt` from my command line I see the following...

```
Running "lint:all" (lint) task
Lint free.

Running "jasmine_node" task

Calculator

    add()
        adds two numbers together

Finished in 0.004 seconds
1 test, 1 assertion, 0 failures



Done, without errors.
```

This PR should be backward compatible with projectRoot but also provides a new `specFolders` option in the grunt config.
