### PR TITLE
make useCoffee option actually work

### DIFF
--- a/tasks/jasmine-node-task.js
+++ b/tasks/jasmine-node-task.js
@@ -56,6 +56,10 @@ module.exports = function (grunt) {
       // Tell grunt this task is asynchronous.
       var done = this.async();
 
+      if (useCoffee) {
+        extensions = 'js|coffee|litcoffee';
+      }
+
       var regExpSpec = new RegExp(match + (matchall ? "" : specNameMatcher + "\\.") + "(" + extensions + ")$", 'i');
       var onComplete = function(runner, log) {
         var exitCode;
@@ -77,14 +81,12 @@ module.exports = function (grunt) {
         match:           match,
         matchall:        matchall,
         specNameMatcher: specNameMatcher,
-        extensions:      extensions,
         specFolders:     specFolders,
         onComplete:      onComplete,
         isVerbose:       isVerbose,
         showColors:      showColors,
         teamcity:        teamcity,
         useRequireJs:    useRequireJs,
-        coffee:          useCoffee,
         regExpSpec:      regExpSpec,
         junitreport:     jUnit
       };


### PR DESCRIPTION
Fixed the `useCoffee` option to actually work. The `extensions` and `coffee` parameter are not actually used in the `jasmine.executeSpecsInFolder` method. These are parsed and setup similarly to what I added here in the jasmine-node cli.js file. My recommendation is to look at refactoring this into the `executeSpecsInFolder` method somehow in the jasmine-node project. For now, this will work.
