### PR TITLE
Added useProjectRoot parameter to force runner to only use specFolders v...

### DIFF
--- a/tasks/jasmine-node-task.js
+++ b/tasks/jasmine-node-task.js
@@ -16,7 +16,8 @@ module.exports = function (grunt) {
       }
 
       var projectRoot     = grunt.config("jasmine_node.projectRoot") || ".";
-      var specFolders     = grunt.config("jasmine_node.specFolders") || [];
+      var specFolders	 = grunt.config("jasmine_node.specFolders") || [];
+      var useProjectRoot  = grunt.config("jasmine_node.useProjectRoot") !== false ? true : false;
       var source          = grunt.config("jasmine_node.source") || "src";
       var specNameMatcher = grunt.config("jasmine_node.specNameMatcher") || "spec";
       var teamcity        = grunt.config("jasmine_node.teamcity") || false;
@@ -32,7 +33,7 @@ module.exports = function (grunt) {
       var isVerbose       = grunt.config("jasmine_node.verbose");
       var showColors      = grunt.config("jasmine_node.colors");
 
-      if (projectRoot) {
+      if (useProjectRoot) {
         specFolders.push(projectRoot);
       }
 


### PR DESCRIPTION
Added useProjectRoot parameter to force runner to only use specFolders values.  Comparison is explicit so anything other than false will result in a true.  True is the default functionality that existed before.
