### PR TITLE
Stop running tests twice

### DIFF
--- a/tasks/jasmine-node-task.js
+++ b/tasks/jasmine-node-task.js
@@ -32,7 +32,7 @@ module.exports = function (grunt) {
       var isVerbose       = grunt.config("jasmine_node.verbose");
       var showColors      = grunt.config("jasmine_node.colors");
 
-      if (projectRoot) {
+      if (projectRoot && specFolders.length < 1) {
         specFolders.push(projectRoot);
       }
 


### PR DESCRIPTION
When I specify a value for specFolders it adds projectRoot to this list
and ends up running my tests twice.  It does so even if I do not
specify a projectRoot, because projectRoot defaults to '.'

This change prevents the bad behavior by not adding projectRoot to the
specFolders list if the list already has one or more entries.
