### PR TITLE
Fix example Gruntfile.js

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -25,6 +25,7 @@ module.exports = function (grunt) {
 				matchall: false,
 				extensions: 'js',
 				specNameMatcher: 'spec',
+				specFolders: ['spec'],
 				jUnit: {
 					report: false,
 					savePath : "./build/reports/jasmine/",


### PR DESCRIPTION
The current Gruntfile.js has all of its settings in an options object, which is not what the task looks for. Pulling the options out of the options object does the trick. I also renamed the "all" setting to "specFolders", because there is no "all" setting in the task.
