### PR TITLE
Fail grunt task if jasmine-node fails.

### DIFF
--- a/tasks/jasmine-node-task.js
+++ b/tasks/jasmine-node-task.js
@@ -70,7 +70,7 @@ module.exports = function (grunt) {
           }
         }
 
-        done();
+        done(exitCode === 0);
       };
 
       var options = {


### PR DESCRIPTION
Currently, grunt does not fail if there are failing tests, see:
https://travis-ci.org/angular/angular.js/builds/14329011#L2366
(Successful build, even though jasmine-node failed)
