### PR TITLE
Use `grunt.option` to check for verbose flag

### DIFF
--- a/tasks/jasmine-node-task.js
+++ b/tasks/jasmine-node-task.js
@@ -70,7 +70,7 @@ module.exports = function (grunt) {
       var jasmineOptions = {
         specFolders: options.specFolders,
         onComplete:   onComplete,
-        isVerbose: grunt.verbose?true:options.verbose,
+        isVerbose: grunt.option('verbose')?true:options.verbose,
         showColors: options.showColors,
         teamcity: options.teamcity,
         useRequireJs: options.useRequireJs,


### PR DESCRIPTION
`grunt.verbose` is a large object, and always evaluates to true, leaving no way of disabling verbose output.