### PR TITLE
feat(package.json): bump up jasmine-node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {},
   "dependencies": {
-    "jasmine-node": "~1.7.0",
+    "jasmine-node": "~1.14.0",
     "coffee-script": "~1.6.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This fixes jasmine-node dependencies and allows running grunt-jasmine-node again in the presence of jasmine `v2.0.0`.