### PR TITLE
use caret for jasmine-node dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {},
   "dependencies": {
-    "jasmine-node": "~1.7.0",
+    "jasmine-node": "^1.14.5",
     "coffee-script": "~1.6.2"
   },
   "devDependencies": {


### PR DESCRIPTION
according to [this issue](https://github.com/mhevery/jasmine-node/pull/339) jasmine-node threw errors when using a new version of jasmine-reporters. they downgraded their dependency to only use 1.x.x versions

this pull request just upgrades the dependency to jasmine-node to the current version + uses a caret instead of a tilde. that means that all minor upgrades (and not just patches) of jasmine-node will be automatically installed in the future.

if you are not comfortable using the caret (i know their a pro's and con's), please at least upgrade the jasmine-node-version