### PR TITLE
Removing jUnit from usage example as it doesn't work out-of-the-box.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,7 @@ grunt.initConfig({
       match: '.',
       matchall: false,
       extensions: 'js',
-      specNameMatcher: 'spec',
-      jUnit: {
-        report: true,
-        savePath : "./build/reports/jasmine/",
-        useDotNotation: true,
-        consolidate: true
-      }
+      specNameMatcher: 'spec'
     },
     all: ['spec/']
   }


### PR DESCRIPTION
Using the example setup outputs the following error:

````
Failed to execute "jasmine.executeSpecsInFolder": TypeError: undefined is not a function
    at Object.jasmine.executeSpecsInFolder (/Users/mcarey/projects/dorightdigital/tools/js-config/node_modules/grunt-jasmine-node/node_modules/jasmine-node/lib/jasmine-node/index.js:100:28)
    at Object.<anonymous> (/Users/mcarey/projects/dorightdigital/tools/js-config/node_modules/grunt-jasmine-node/tasks/jasmine-node-task.js:96:17)
    at Object.<anonymous> (/Users/mcarey/projects/dorightdigital/tools/js-config/node_modules/grunt/lib/grunt/task.js:264:15)
    at Object.thisTask.fn (/Users/mcarey/projects/dorightdigital/tools/js-config/node_modules/grunt/lib/grunt/task.js:82:16)
    at Object.<anonymous> (/Users/mcarey/projects/dorightdigital/tools/js-config/node_modules/grunt/lib/util/task.js:301:30)
    at Task.runTaskFn (/Users/mcarey/projects/dorightdigital/tools/js-config/node_modules/grunt/lib/util/task.js:251:24)
    at Task.<anonymous> (/Users/mcarey/projects/dorightdigital/tools/js-config/node_modules/grunt/lib/util/task.js:300:12)
    at /Users/mcarey/projects/dorightdigital/tools/js-config/node_modules/grunt/lib/util/task.js:227:11
    at process._tickCallback (node.js:442:13)
    at Function.Module.runMain (module.js:499:11)
````
It's a symptom of telling jasmine-node to use junit for reporting without setting up a junit reporter.  Someone who cares enough about junit reporting should be able to resolve the real issue with the reporting but for now I'd recommend you don't encourage people to use it by default (especially as it's not coded as the default behaviour).

Hope that helps.

Mat