### PR TITLE
[FIX] options.isVerbose was not passed to jasmine

### DIFF
--- a/tasks/jasmine-node-task.js
+++ b/tasks/jasmine-node-task.js
@@ -113,7 +113,7 @@ module.exports = function (grunt) {
       var jasmineOptions = {
         specFolders:        options.specFolders,
         onComplete:         onComplete,
-        isVerbose:          grunt.option('verbose')?true:options.verbose,
+        isVerbose:          grunt.option('verbose')?true:options.isVerbose,
         showColors:         options.showColors,
         teamcity:           options.teamcity,
         useRequireJs:       options.useRequireJs,


### PR DESCRIPTION
jasmine option: `isVerbose` was not being used from the grunt config
